### PR TITLE
Atom feed: support titles with implicit type.

### DIFF
--- a/jquery.lifestream.js
+++ b/jquery.lifestream.js
@@ -198,7 +198,7 @@ $.fn.lifestream.feeds.atom = function( config, callback ) {
 
   var template = $.extend({},
     {
-      posted: 'posted <a href="${link.href}">${title.content}</a>'
+      posted: 'posted <a href="${link.href}">${typeof title === "object" ? title.content : title}</a>'
     },
     config.template),
 


### PR DESCRIPTION
According to the Atom spec, text constructs such as title may have
a type attribute, but if they don't, processors must behave as
though it were present with a value of "text".

YQL treats these two cases differently:

    "title": {"type": "html", "content": "HTML content"}
    "title": "Text content with unspecified type."

With this change, we use the content property if `title` is an
object, and otherwise use `title` as-is.